### PR TITLE
feat: display account names instead of IDs in transaction entries

### DIFF
--- a/src/pages/view-transactions-page.tsx
+++ b/src/pages/view-transactions-page.tsx
@@ -231,7 +231,7 @@ const ViewTransactionsPage: React.FC = () => {
                                     Amount
                                   </TableColumn>
                                   <TableColumn className="text-xs">
-                                    Account ID
+                                    Account Name
                                   </TableColumn>
                                   <TableColumn className="text-xs">
                                     Type
@@ -254,9 +254,9 @@ const ViewTransactionsPage: React.FC = () => {
                                       </TableCell>
                                       <TableCell
                                         className="text-xs truncate"
-                                        title={entry.account_id}
+                                        title={entry.account.account_name}
                                       >
-                                        {entry.account_id}
+                                        {entry.account.account_name}
                                       </TableCell>
                                       <TableCell className="text-xs">
                                         {entry.entry_type}

--- a/src/types/transaction.types.ts
+++ b/src/types/transaction.types.ts
@@ -1,6 +1,12 @@
 export interface TransactionEntry {
   entry_id: string;
-  account_id: string;
+  account_id?: string;
+  account: {
+    account_id: string;
+    merchant_id: string;
+    account_name: string;
+    account_type: string;
+  };
   transaction_id: string;
   entry_type: "DEBIT" | "CREDIT";
   amount: string;


### PR DESCRIPTION
## Summary
- Display account names instead of account IDs in the transaction entries table for better readability
- Update the TransactionEntry type to include the account object with account details

## Changes
- Changed table column header from "Account ID" to "Account Name"
- Updated the display to show `entry.account.account_name` instead of `entry.account_id`
- Modified TransactionEntry interface to include the account object containing account_id, merchant_id, account_name, and account_type

## Test plan
- [ ] Navigate to the transactions page
- [ ] Select a merchant to view transactions
- [ ] Expand a transaction to view its entries
- [ ] Verify that the "Account Name" column displays readable account names instead of IDs
- [ ] Verify that hovering over account names shows the full name in a tooltip

🤖 Generated with [Claude Code](https://claude.ai/code)